### PR TITLE
Enable deep clones for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ services:
 addons:
   postgresql: 10
 
+git:
+  depth: false
+
 branches:
   only:
     - master


### PR DESCRIPTION
Deploys to gigalixir have been failing because, by default, Travis CI
only does shallow clones. This removes the depth flag entirely so that
a deep clone is performed in Travis.